### PR TITLE
Add missing clang include files for swift

### DIFF
--- a/srcpkgs/swift/template
+++ b/srcpkgs/swift/template
@@ -61,6 +61,8 @@ do_install() {
 	vman docs/tools/swift.1
 	vmkdir usr/lib/swift
 	vcopy lib/swift/* usr/lib/swift
+	vmkdir usr/lib/swift/clang/include
+	vcopy ../llvm-linux-${XBPS_TARGET_MACHINE}/lib/clang/3.8.0/include/* usr/lib/swift/clang/include
 # EXPERIMENTAL
 #	(
 #		cd foundation-linux-${_arch}

--- a/srcpkgs/swift/template
+++ b/srcpkgs/swift/template
@@ -60,6 +60,7 @@ do_install() {
 	vbin bin/swift-autolink-extract
 	vman docs/tools/swift.1
 	vmkdir usr/lib/swift
+	rm -f lib/swift/clang
 	vcopy lib/swift/* usr/lib/swift
 	vmkdir usr/lib/swift/clang/include
 	vcopy ../llvm-linux-${XBPS_TARGET_MACHINE}/lib/clang/3.8.0/include/* usr/lib/swift/clang/include


### PR DESCRIPTION
Finally allows to import glibc in swift applications (see [#3893](https://github.com/voidlinux/void-packages/pull/3893)). Directory structure is taken from the reference Ubuntu build.
