### PR TITLE
Correct revision, remove unnecessary directory

### DIFF
--- a/srcpkgs/swift/template
+++ b/srcpkgs/swift/template
@@ -50,7 +50,7 @@ do_build() {
 
 do_install() {
 	vlicense LICENSE.txt
-	cd ../build/Ninja-ReleaseAssert/swift-linux-${XBPS_TARGET_ARCH}
+	cd ../build/Ninja-ReleaseAssert/swift-linux-${XBPS_TARGET_MACHINE}
 	vbin bin/sil-opt
 	vbin bin/sil-extract
 	vbin bin/swift

--- a/srcpkgs/swift/template
+++ b/srcpkgs/swift/template
@@ -61,6 +61,8 @@ do_install() {
 	vman docs/tools/swift.1
 	vmkdir usr/lib/swift
 	vcopy lib/swift/* usr/lib/swift
+	vmkdir usr/lib/swift/clang/include
+	vcopy ../llvm-linux-${XBPS_TARGET_MACHINE}/lib/clang/3.8.0/include/* usr/lib/swift/clang/include
 # EXPERIMENTAL
 #	(
 #		cd foundation-linux-${_arch}

--- a/srcpkgs/swift/template
+++ b/srcpkgs/swift/template
@@ -1,10 +1,10 @@
 # Template file for 'swift'
 pkgname=swift
 version=2.2
-revision=1
+revision=2
 nocross=yes
 makedepends="libxml2-devel libuuid-devel libbsd-devel icu-devel libedit-devel"
-only_for_archs="i686 x86_64 armv7l aarch64 mips mipsel"
+only_for_archs="x86_64"
 hostmakedepends="pkg-config ninja cmake icu swig clang python perl"
 short_desc="The Swift Programming Language"
 maintainer="pancake <pancake@nopcode.org>"
@@ -60,8 +60,7 @@ do_install() {
 	vbin bin/swift-autolink-extract
 	vman docs/tools/swift.1
 	vmkdir usr/lib/swift
-	cp -rf lib/swift/* ${PKGDESTDIR}/usr/lib/swift
-
+	vcopy lib/swift/* usr/lib/swift
 # EXPERIMENTAL
 #	(
 #		cd foundation-linux-${_arch}

--- a/srcpkgs/swift/template
+++ b/srcpkgs/swift/template
@@ -1,7 +1,7 @@
 # Template file for 'swift'
 pkgname=swift
 version=2.2
-revision=2
+revision=1
 nocross=yes
 makedepends="libxml2-devel libuuid-devel libbsd-devel icu-devel libedit-devel"
 only_for_archs="x86_64"
@@ -60,6 +60,7 @@ do_install() {
 	vbin bin/swift-autolink-extract
 	vman docs/tools/swift.1
 	vmkdir usr/lib/swift
+	rm -r -f lib/swift/install-tmp
 	rm -f lib/swift/clang
 	vcopy lib/swift/* usr/lib/swift
 	vmkdir usr/lib/swift/clang/include

--- a/srcpkgs/swift/template
+++ b/srcpkgs/swift/template
@@ -60,6 +60,7 @@ do_install() {
 	vbin bin/swift-autolink-extract
 	vman docs/tools/swift.1
 	vmkdir usr/lib/swift
+	rm -f lib/swift/clang
 	vcopy lib/swift/* usr/lib/swift
 	vmkdir usr/lib/swift/clang/include
 	vcopy ../llvm-linux-${XBPS_TARGET_MACHINE}/lib/clang/3.8.0/include/* usr/lib/swift/clang/include

--- a/srcpkgs/swift/template
+++ b/srcpkgs/swift/template
@@ -1,0 +1,73 @@
+# Template file for 'swift'
+pkgname=swift
+version=2.2
+revision=1
+nocross=yes
+makedepends="libxml2-devel libuuid-devel libbsd-devel icu-devel libedit-devel sqlite-devel"
+only_for_archs="i686 x86_64 armv7l aarch64 mips mipsel"
+hostmakedepends="pkg-config ninja cmake icu swig clang python perl"
+short_desc="The Swift Programming Language"
+maintainer="pancake <pancake@nopcode.org>"
+license="Apache-2.0"
+homepage="https://www.swift.org/"
+_head="https://github.com/apple/"
+_tail="archive/${pkgname}-${version}-RELEASE.tar.gz"
+wrksrc="swift-swift-${version}-RELEASE"
+distfiles="
+${_head}/swift/${_tail}>swift-${version}.tar.gz
+${_head}/swift-llvm/${_tail}>swift-llvm-${version}.tar.gz
+${_head}/swift-clang/${_tail}>swift-clang-${version}.tar.gz
+${_head}/swift-lldb/${_tail}>swift-lldb-${version}.tar.gz
+${_head}/swift-cmark/${_tail}>swift-cmark-${version}.tar.gz
+"
+checksum="
+6dfb9de14201b9804974b1f221573cfb3e24fd657ec3bf132bf3c75de02565f5
+b975b816773aa9d888a9139f51acd1b57fd58959bb391f8f65645a2f9b6d4cc4
+ba9220e61971a55d13f501dc30f452a5c272e4d897b444a5220f2e23dbbfc2f8
+b562fee1963900c86fed016408e3acbb63500a3603f4af70928c11ce376b9a72
+09c8da18c37f32cd0eb82b252a172481f5403c1bc6ab5740f92e87f8d1e79991
+83d9d99b635bbc6b95d52b645df97140d5596cfb746001d67bf9e8d5824fb339
+"
+
+# EXPERIMENTAL DEPENDENCIES
+# =========================
+# swift-llbuild
+# swift-package-manager
+# swift-corelibs-xctest
+# swift-corelibs-foundation
+
+do_build() {
+	(
+		cd ..
+		for a in llvm clang lldb cmark; do
+			ln -sf swift-${a}-swift-${version}-RELEASE ${a}
+		done
+		ln -sf swift-swift-${version}-RELEASE swift
+	)
+	export LDFLAGS="-ldl -lpthread"
+	utils/build-script -R -t -j${XBPS_MAKEJOBS}
+}
+
+do_install() {
+	vlicense LICENSE.txt
+	cd ../build/Ninja-ReleaseAssert/swift-linux-${XBPS_TARGET_ARCH}
+	vbin bin/sil-opt
+	vbin bin/sil-extract
+	vbin bin/swift
+	vbin bin/swiftc
+	vbin bin/swift-demangle
+	vbin bin/swift-autolink-extract
+	vman docs/tools/swift.1
+	vmkdir usr/lib/swift
+	cp -rf lib/swift/* ${PKGDESTDIR}/usr/lib/swift
+
+# EXPERIMENTAL
+#	(
+#		cd foundation-linux-${_arch}
+#		vinstall Foundation/libFoundation.so 755 /usr/lib/swift/linux
+#		vinstall Foundation/libFoundation.swiftdoc 644 /usr/lib/swift/linux/${_arch}
+#		vinstall Foundation/libFoundation.swiftmodule 644 /usr/lib/swift/linux/${_arch}
+#		umask 0022
+#		cp -r Foundation/usr/lib/swift/CoreFoundation ${PKGDESTDIR}/usr/lib/swift
+#	)
+}

--- a/srcpkgs/swift/template
+++ b/srcpkgs/swift/template
@@ -3,7 +3,7 @@ pkgname=swift
 version=2.2
 revision=1
 nocross=yes
-makedepends="libxml2-devel libuuid-devel libbsd-devel icu-devel libedit-devel sqlite-devel"
+makedepends="libxml2-devel libuuid-devel libbsd-devel icu-devel libedit-devel"
 only_for_archs="i686 x86_64 armv7l aarch64 mips mipsel"
 hostmakedepends="pkg-config ninja cmake icu swig clang python perl"
 short_desc="The Swift Programming Language"
@@ -43,6 +43,7 @@ do_build() {
 			ln -sf swift-${a}-swift-${version}-RELEASE ${a}
 		done
 		ln -sf swift-swift-${version}-RELEASE swift
+		sed -i 's|/usr/include/x86_64-linux-gnu|/usr/include|g' clang/lib/Driver/ToolChains.cpp
 	)
 	export LDFLAGS="-ldl -lpthread"
 	utils/build-script -R -t -j${XBPS_MAKEJOBS}


### PR DESCRIPTION
I didn't find the /usr/lib/swift/install-tmp in the official Ubuntu build so I think we can safely remove it. It only contained a broken symbolic link to the clang directory.
